### PR TITLE
Add enumeration of unreleased beta versions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+* Add `unreleased_betas` list to enumerate the latest release-candidate
+  version for each unreleased minor OCaml series.
+
 ## v2.3.0 (2019-08-29)
 
 * Support OCaml 4.02.3, which brings back a dependency on

--- a/ocaml_version.ml
+++ b/ocaml_version.ml
@@ -125,6 +125,8 @@ module Releases = struct
   let all = [ v4_00; v4_01; v4_02; v4_03; v4_04;
               v4_05; v4_06; v4_07; v4_08; v4_09; v4_10 ]
 
+  let unreleased_betas = [ of_string_exn "4.10.0+beta1" ]
+
   let recent = [ v4_02; v4_03; v4_04; v4_05; v4_06; v4_07; v4_08; v4_09 ]
 
   let latest = v4_09

--- a/ocaml_version.mli
+++ b/ocaml_version.mli
@@ -256,11 +256,11 @@ module Releases : sig
   (** [latest] is the most recent stable release of OCaml. *)
 
   val recent : t list
-  (** [recent] is the last five releases of OCaml, with each at the latest patch level.
+  (** [recent] is the last eight releases of OCaml, with each at the latest patch level.
       This is the set that is most reliably tested in the opam package repository. *)
 
   val recent_with_dev : t list
-  (** [recent_with_dev] are the last four stable releases of OCaml and the latest
+  (** [recent_with_dev] are the last eight stable releases of OCaml and the latest
       development branches. *)
 
   val is_dev : t -> bool

--- a/ocaml_version.mli
+++ b/ocaml_version.mli
@@ -247,6 +247,10 @@ module Releases : sig
   (** [all] is an enumeration of all the OCaml releases, with the latest patch versions in
       each major and minor release. *)
 
+  val unreleased_betas : t list
+  (** Enumerates the latest beta / release-candidate versions for each {i
+      unreleased} minor OCaml series. *)
+
   val dev : t list
   (** Enumeration of the latest development OCaml releases.
       This is usually just one, but may include two active dev


### PR DESCRIPTION
This is needed for https://github.com/ocurrent/ocaml-ci/issues/96.

Also fixes two typos in the documentation (I think we probably shouldn't have
this information in the documentation if it's going to change on each minor
release...).