### PR TITLE
Add the Opam.V2.package function

### DIFF
--- a/ocaml_version.ml
+++ b/ocaml_version.ml
@@ -364,12 +364,16 @@ let compiler_variants arch ({major; minor; _} as t) =
 module Opam = struct
 
   module V2 = struct
-    let name t =
+    let package t =
       match t.extra with
-      | Some extra when Releases.is_dev t -> Printf.sprintf "ocaml-variants.%s+trunk+%s" (to_string (without_variant t)) extra
-      | Some _ -> "ocaml-variants." ^ (to_string t)
-      | None when Releases.is_dev t -> Printf.sprintf "ocaml-variants.%s+trunk" (to_string t)
-      | None -> "ocaml-base-compiler." ^ (to_string t)
+      | Some extra when Releases.is_dev t -> ("ocaml-variants", Printf.sprintf "%s+trunk+%s" (to_string (without_variant t)) extra)
+      | Some _ -> ("ocaml-variants", to_string t)
+      | None when Releases.is_dev t -> ("ocaml-variants", Printf.sprintf "%s+trunk" (to_string t))
+      | None -> ("ocaml-base-compiler", to_string t)
+
+    let name t =
+      let (name, version) = package t in
+      name ^ "." ^ version
 
     let variant_switch t vs =
       match vs with

--- a/ocaml_version.mli
+++ b/ocaml_version.mli
@@ -335,7 +335,7 @@ module Since : sig
   val bytes: t
   (** [bytes] is the release that the {!Bytes} module first appeared in. *)
 
-  val arch : arch -> t 
+  val arch : arch -> t
   (** [arch a] will return the first release of OCaml that the architecture
       was reasonably stably supported on. *)
 end
@@ -408,8 +408,12 @@ module Opam : sig
 
   (** Opam 2.0 functions *)
   module V2 : sig
+    val package : t -> (string * string)
+    (** [package t] returns the [(name, version)] pair corresponding to the opam2 package
+        for that compiler version. *)
+
     val name : t -> string
-    (** [package t] returns the opam2 package for that compiler version. *)
+    (** [name t] returns the opam2 package for that compiler version. *)
 
     val variant_switch : t -> Configure_options.o list -> t
     (** [variant_switch t cs] returns an OCaml version [t] whose


### PR DESCRIPTION
This function is easier to use compared to `Opam.V2.name` for calls to things like `opam pin add <pkgname> <pkgver>`