### PR TITLE
Support proposed ocaml-options-* packages

### DIFF
--- a/ocaml_version.ml
+++ b/ocaml_version.ml
@@ -441,20 +441,15 @@ module Opam = struct
       if t.major <> 4 || t.minor <> 12 then
         []
       else
-        (* FIXME This is done with ocaml-options packages, not with ocaml-options-only packages.
-                 It's a straightforward adaptation of Configure_options.to_t's logic, but the PR
-                 doesn't include all the required ocaml-options-only-* packages yet *)
-        let option_package = function
-        | `Afl -> Some "ocaml-options-afl"
-        | `Flambda -> Some "ocaml-options-flambda"
-        | `Default_unsafe_string -> Some "ocaml-options-default-unsafe-string"
-        | `Disable_flat_float_array -> Some "ocaml-options-no-flat-float-array"
-        | `Force_safe_string -> None
-        | `Frame_pointer -> Some "ocaml-options-fp"
-        | `No_naked_pointers -> Some "ocaml-options-nnp"
-        in
-          Result.map (List.filter_map option_package) (Configure_options.of_t t)
-          |> Result.value ~default:[]
+        match Configure_options.of_t t with
+        | Ok []
+        | Error _ -> []
+        | Ok options ->
+            let options_only_package =
+              List.map Configure_options.to_string options
+              |> String.concat "-"
+              |> (^) "ocaml-options-only-" in
+            [options_only_package]
 
     let name t =
       let (name, version) = package t in

--- a/ocaml_version.mli
+++ b/ocaml_version.mli
@@ -429,6 +429,10 @@ module Opam : sig
     (** [package t] returns the [(name, version)] pair corresponding to the opam2 package
         for that compiler version. *)
 
+    val additional_packages : t -> string list
+    (** [additional_packages t] returns the list of opam packages which need to
+        be installed in addition to the {!package}[ t]. *)
+
     val name : t -> string
     (** [name t] returns the opam2 package for that compiler version. *)
 


### PR DESCRIPTION
ocaml/opam-repository#17541 seeks to solve the combinatorial explosion of `ocaml-variants` packages, with a trial for the 4.12 packages only.

This means that instead of installing, for example, `ocaml-variants.4.12.0+trunk+fp+flambda`, one now installs `ocaml-variants.4.12.0+trunk` and also `ocaml-options-only-flambda-fp`.