### PR TITLE
ocaml-option-* layout has been adopted for 4.12+

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,9 @@
 ## dev
 
+* Add OCaml 4.11.2 and 4.12.0 (@smorimoto @kit-ty-kate)
 * Add OCaml 4.10.2 and 4.11.1 release. (@avsm)
-* Add Releases.uses_options_packages and update for new opam-repository
-  layout for 4.12+. (@dra27)
+* Add `Since.options_packages` and update for new opam-repository
+  layout for 4.12+. (@dra27 @avsm)
 
 ## v3.0.0 (2020-08-23)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 ## dev
 
 * Add OCaml 4.10.2 and 4.11.1 release. (@avsm)
+* Add Releases.uses_options_packages and update for new opam-repository
+  layout for 4.12+. (@dra27)
 
 ## v3.0.0 (2020-08-23)
 

--- a/ocaml_version.mli
+++ b/ocaml_version.mli
@@ -336,6 +336,7 @@ module Releases : sig
   val is_dev : t -> bool
   (** [is_dev t] will return true if the release [t] represents a development
       release instead of a stable archive. *)
+
 end
 
 (** Values relating to the source code and version control of OCaml *)
@@ -361,6 +362,10 @@ module Since : sig
   val arch : arch -> t
   (** [arch a] will return the first release of OCaml that the architecture
       was reasonably stably supported on. *)
+
+  val options_packages : t
+  (** [options_packages t] will return the first release of OCaml that uses [ocaml-option-*]
+      packages in opam-repository, rather than +variant packages *)
 end
 
 (** Test whether a release has a given feature. *)
@@ -372,6 +377,10 @@ module Has : sig
 
   val arch : arch -> t -> bool
   (** [arch a t] will return {!true} if architecture [a] is supported on release [t]. *)
+
+  val options_packages : t -> bool
+  (** [options_packages t] will return true if the release [t] uses [ocaml-option-*]
+      packages in opam-repository, rather than +variant packages *)
 end
 
 (** Configuration parameters that affect the behaviour of OCaml at compiler-build-time. *)
@@ -408,12 +417,13 @@ module Configure_options : sig
   val to_configure_flag : t -> o -> string
   (** [to_configure_flag o] returns a string that can be passed to OCaml's [configure] script to activate that feature. *)
 
-  val compare : o -> o -> int
-  (** [compare a b] will return -1 if [a] is < [b], 0 if they are equal, or 1 if [a] > [b]. For backwards
-      compatibility reasons, {!`Frame_pointer} always comes first in comparisons. *)
+  val compare : t -> o -> o -> int
+  (** [compare t a b] will return -1 if [a] is < [b], 0 if they are equal, or 1 if [a] > [b]. For backwards
+      compatibility reasons, {!`Frame_pointer} always comes first in comparisons before OCaml 4.12.0, and
+      is lexically ordered after 4.12.0.  The [t] argument will determine which comparison function to use.  *)
 
-  val equal : o -> o -> bool
-  (** [equal a b] will return {!true} if [a=b] *)
+  val equal : t -> o -> o -> bool
+  (** [equal t a b] will return {!true} if [a=b] for a given OCaml version [t]. *)
 
 end
 


### PR DESCRIPTION
I haven't fired up my ocluster to check it with docker-base-images, but this seems to be producing the right answers:

```
utop # Ocaml_version.Opam.V2.package Ocaml_version.Releases.v4_12;;
- : string * string = ("ocaml-base-compiler", "4.12.0")
utop # Ocaml_version.Opam.V2.package Ocaml_version.(with_variant Releases.v4_12 (Some "flambda"));;
- : string * string = ("ocaml-variants", "4.12.0+options")
utop # Ocaml_version.Opam.V2.additional_packages Ocaml_version.(with_variant Releases.v4_12 (Some "flambda"));;
- : string list = ["ocaml-options-only-flambda"]
utop # Ocaml_version.Opam.V2.package Ocaml_version.(with_variant Releases.v4_13 (Some "flambda"));;
- : string * string = ("ocaml-variants", "4.13.0+trunk")
utop # Ocaml_version.Opam.V2.additional_packages Ocaml_version.(with_variant Releases.v4_13 (Some "flambda"));;
- : string list = ["ocaml-options-only-flambda"]
```