### PR TITLE
add a multicore variant

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 * Add support for naked pointers checker option and add it to
   the 4.12+ variants (@kit-ty-kate @dra27 @avsm)
+* Add a multicore and multicore-fibres variant for the experimental
+  forks in 4.10, to aid in CI. (@avsm)
 
 ## v3.1.0 (2021-02-25)
 

--- a/ocaml_version.mli
+++ b/ocaml_version.mli
@@ -381,6 +381,11 @@ module Has : sig
   val options_packages : t -> bool
   (** [options_packages t] will return true if the release [t] uses [ocaml-option-*]
       packages in opam-repository, rather than +variant packages *)
+
+  val multicore : t -> bool
+  (** [multicore t] will return true if the release [t] has a multicore OCaml fork
+      available for it.  This requires the [https://github.com/ocaml-multicore/multicore-opam]
+      opam switch to be added before the package is available. *)
 end
 
 (** Configuration parameters that affect the behaviour of OCaml at compiler-build-time. *)
@@ -393,6 +398,8 @@ module Configure_options : sig
     | `Flambda
     | `Force_safe_string
     | `Frame_pointer
+    | `Multicore
+    | `Multicore_no_effect_syntax
     | `No_naked_pointers
     | `No_naked_pointers_checker ]
 
@@ -448,7 +455,7 @@ module Opam : sig
 
     val additional_packages : t -> string list
     (** [additional_packages t] returns the list of opam packages which need to
-        be installed in addition to the {!package}[ t]. *)
+        be installed in addition to the {!package} [t]. *)
 
     val name : t -> string
     (** [name t] returns the opam2 package for that compiler version. *)


### PR DESCRIPTION
Although there is no configure flag for multicore, it is useful to have this in order to hook in the multicore OCaml fork into the docker base images builder.