### PR TITLE
Fix the variants for multicore on Ocaml 4.12.

### DIFF
--- a/ocaml_version.mli
+++ b/ocaml_version.mli
@@ -385,16 +385,25 @@ module Has : sig
   val multicore : t -> bool
   (** [multicore t] will return true if the release [t] has a multicore OCaml fork
       available for it.  This requires the [https://github.com/ocaml-multicore/multicore-opam]
-      opam switch to be added before the package is available. *)
+      opam switch to be added before the package is available.
+
+      Note that the multicore variants changed between 4.10 and 4.12, and this
+      function returns true for any of them. *)
 end
 
 (** Configuration parameters that affect the behaviour of OCaml at compiler-build-time. *)
 module Configure_options : sig
-
+  (*
+   The variants for multicore changed between 4.10 and 4.12.
+   Multicore and Multicore_no_effect_syntax are used with 4.10 (+multicore and +multicore+no-effect-syntax).
+   Domains and Effects are used with 4.12 (+domains and +domains+effects).
+  *)
   type o =
     [ `Afl
     | `Default_unsafe_string
     | `Disable_flat_float_array
+    | `Domains
+    | `Effects
     | `Flambda
     | `Force_safe_string
     | `Frame_pointer

--- a/test/test_unit.ml
+++ b/test/test_unit.ml
@@ -17,5 +17,29 @@ let test_configure_options =
     test "FP on 3.12" v3_12 `Frame_pointer ~expected:"-with-frame-pointer";
   ]
 
+let test_compiler_variants =
+  let test ?(expect_exists=true) name arch version ~expected =
+    ( name,
+      `Quick,
+      fun () ->
+        let got = Ocaml_version.compiler_variants arch version in
+        let all_ok = expected |> List.for_all (
+          fun expected_extra ->
+            let exists = got |> List.exists (fun v -> Ocaml_version.extra v = Some expected_extra) in
+            exists = expect_exists
+        ) in
+        Alcotest.(check bool __LOC__ all_ok true) )
+  in
+  Ocaml_version.Releases.([
+    test "Multicore on 4.10 x86-64" `X86_64 v4_10
+      ~expected:["multicore"; "multicore+no-effect-syntax"];
+    test "Multicore on 4.12 x86-64" `X86_64 v4_12
+      ~expected:["domains"; "domains+effects"];
+    test "Multicore not on 4.10 i386" `I386 v4_10
+      ~expect_exists:false ~expected:["domains"; "multicore"];
+    test "Multicore not on 4.12 xi386" `I386 v4_12
+      ~expect_exists:false ~expected:["domains"; "multicore"]
+  ])
+
 let () =
-  Alcotest.run "ocaml-version" [ ("Configure_options", test_configure_options) ]
+  Alcotest.run "ocaml-version" [ ("Compiler_variants", test_compiler_variants); ("Configure_options", test_configure_options) ]


### PR DESCRIPTION
The variant names have changed:

4.10.x+multicore+no-effect-syntax
4.10.x+multicore
4.12.x+domains
4.12.x+domains+effects

Signed-off-by: Ewan Mellor <ewan@tarides.com>