### PR TITLE
Add 5.00.0

### DIFF
--- a/ocaml_version.ml
+++ b/ocaml_version.ml
@@ -38,11 +38,12 @@ let to_string ?prerelease_sep ?sep v =
   let presep, sep = choose_seps ~prerelease_sep ~sep in
   let prerelease = with_sep ~sep:presep v.prerelease in
   let extra = with_sep ~sep v.extra in
+  let minor_fmt = format_of_string (if v.major >= 5 then "%d" else "%02d") in
   match v.patch with
   | None ->
-    Printf.sprintf "%d.%02d%s%s" v.major v.minor prerelease extra
+    Printf.sprintf "%d.%(%d%)%s%s" v.major minor_fmt v.minor prerelease extra
   | Some patch ->
-    Printf.sprintf "%d.%02d.%d%s%s" v.major v.minor patch prerelease extra
+    Printf.sprintf "%d.%(%d%).%d%s%s" v.major minor_fmt v.minor patch prerelease extra
 
 let parse s =
   let build patch major minor sep extra =

--- a/ocaml_version.ml
+++ b/ocaml_version.ml
@@ -170,24 +170,29 @@ module Releases = struct
   let v4_14_0 = of_string_exn "4.14.0"
   let v4_14 = v4_14_0
 
+  let v5_00_0 = of_string_exn "5.00.0"
+  let v5_00 = v5_00_0
+
   let all_patches = [
     v4_00_1; v4_01_0; v4_02_0; v4_02_1; v4_02_2;
     v4_02_3; v4_03_0; v4_04_0; v4_04_1; v4_04_2;
     v4_05_0; v4_06_0; v4_06_1; v4_07_0; v4_07_1;
     v4_08_0; v4_08_1; v4_09_0; v4_09_1; v4_10_0;
     v4_10_1; v4_10_2; v4_11_0; v4_11_1; v4_11_2;
-    v4_12_0; v4_12_1; v4_13_0; v4_13_1; v4_14_0 ]
+    v4_12_0; v4_12_1; v4_13_0; v4_13_1; v4_14_0;
+    v5_00_0 ]
 
   let all = [ v4_00; v4_01; v4_02; v4_03; v4_04;
               v4_05; v4_06; v4_07; v4_08; v4_09;
-              v4_10; v4_11; v4_12; v4_13; v4_14 ]
+              v4_10; v4_11; v4_12; v4_13; v4_14;
+              v5_00 ]
 
   let recent = [ v4_02; v4_03; v4_04; v4_05; v4_06; v4_07; v4_08; v4_09; v4_10; v4_11; v4_12; v4_13 ]
 
   let latest = v4_13
 
   let unreleased_betas = [ v4_14 ]
-  let dev = [ v4_14 ]
+  let dev = [ v4_14; v5_00 ]
 
   let trunk =
     match dev with
@@ -453,10 +458,10 @@ module Sources = struct
 end
 
 let trunk_variants (arch:arch) =
-  let base = [[]; [`No_naked_pointers]; [`Afl]; [`Flambda]; [`Disable_flat_float_array]] in
+  let base = [[]; [`Afl]; [`Flambda]; [`Disable_flat_float_array]] in
   let arch_opts =
     match arch with
-    |`X86_64 -> [[`Frame_pointer]; [`Frame_pointer;`Flambda]; [`No_naked_pointers_checker]]
+    |`X86_64 -> [[`Frame_pointer]; [`Frame_pointer;`Flambda]]
     |_ -> []
   in
   List.map (Configure_options.to_t Sources.trunk) (base @ arch_opts)

--- a/ocaml_version.ml
+++ b/ocaml_version.ml
@@ -170,8 +170,8 @@ module Releases = struct
   let v4_14_0 = of_string_exn "4.14.0"
   let v4_14 = v4_14_0
 
-  let v5_00_0 = of_string_exn "5.00.0"
-  let v5_00 = v5_00_0
+  let v5_0_0 = of_string_exn "5.0.0"
+  let v5_0 = v5_0_0
 
   let all_patches = [
     v4_00_1; v4_01_0; v4_02_0; v4_02_1; v4_02_2;
@@ -180,19 +180,19 @@ module Releases = struct
     v4_08_0; v4_08_1; v4_09_0; v4_09_1; v4_10_0;
     v4_10_1; v4_10_2; v4_11_0; v4_11_1; v4_11_2;
     v4_12_0; v4_12_1; v4_13_0; v4_13_1; v4_14_0;
-    v5_00_0 ]
+    v5_0_0 ]
 
   let all = [ v4_00; v4_01; v4_02; v4_03; v4_04;
               v4_05; v4_06; v4_07; v4_08; v4_09;
               v4_10; v4_11; v4_12; v4_13; v4_14;
-              v5_00 ]
+              v5_0 ]
 
   let recent = [ v4_02; v4_03; v4_04; v4_05; v4_06; v4_07; v4_08; v4_09; v4_10; v4_11; v4_12; v4_13 ]
 
   let latest = v4_13
 
   let unreleased_betas = [ v4_14 ]
-  let dev = [ v4_14; v5_00 ]
+  let dev = [ v4_14; v5_0 ]
 
   let trunk =
     match dev with

--- a/ocaml_version.mli
+++ b/ocaml_version.mli
@@ -320,6 +320,12 @@ module Releases : sig
   val v4_14 : t
   (** Latest release in the 4.14.x series *)
 
+  val v5_00_0 : t
+  (** Version 5.00.0 *)
+
+  val v5_00 : t
+  (** Latest release in the 5.00.x series *)
+
   val all_patches : t list
   (** [all_patches] is an enumeration of all OCaml releases, including every patch release.
       To get the major and minor releases with the latest patch version, use {!all} instead. *)

--- a/ocaml_version.mli
+++ b/ocaml_version.mli
@@ -320,11 +320,11 @@ module Releases : sig
   val v4_14 : t
   (** Latest release in the 4.14.x series *)
 
-  val v5_00_0 : t
-  (** Version 5.00.0 *)
+  val v5_0_0 : t
+  (** Version 5.0.0 *)
 
-  val v5_00 : t
-  (** Latest release in the 5.00.x series *)
+  val v5_0 : t
+  (** Latest release in the 5.0.x series *)
 
   val all_patches : t list
   (** [all_patches] is an enumeration of all OCaml releases, including every patch release.


### PR DESCRIPTION
OCaml 4.14.0~alpha1 was released in https://github.com/ocaml/opam-repository/pull/20495
There are also currently no docker images to test trunk and that would be nice to have too