### PR TITLE
Update for OCaml 5.0.0 release

### DIFF
--- a/ocaml_version.ml
+++ b/ocaml_version.ml
@@ -191,12 +191,11 @@ module Releases = struct
               v4_10; v4_11; v4_12; v4_13; v4_14;
               v5_0; v5_1 ]
 
-  let recent = [ v4_02; v4_03; v4_04; v4_05; v4_06; v4_07; v4_08; v4_09; v4_10; v4_11; v4_12; v4_13; v4_14 ]
+  let recent = [ v4_02; v4_03; v4_04; v4_05; v4_06; v4_07; v4_08; v4_09; v4_10; v4_11; v4_12; v4_13; v4_14; v5_0 ]
 
-  let latest = v4_14
+  let latest = v5_0
 
-  let unreleased_betas = [ v5_0_0 ]
-  let dev = [ v5_0; v5_1 ]
+  let dev = [ v5_1 ]
 
   let trunk =
     match dev with

--- a/ocaml_version.ml
+++ b/ocaml_version.ml
@@ -195,6 +195,7 @@ module Releases = struct
 
   let latest = v5_0
 
+  let unreleased_betas = [ ]
   let dev = [ v5_1 ]
 
   let trunk =


### PR DESCRIPTION
This draft PR registers OCaml 5.0 as a released version of OCaml. 

I will remove the draft status once the github archive for OCaml 5.0 is available. 