### PR TITLE
flambda does not compile on arm64 with OCaml < 4.06

### DIFF
--- a/ocaml_version.ml
+++ b/ocaml_version.ml
@@ -525,7 +525,8 @@ let compiler_variants arch ({major; minor; _} as t) =
             variants in
         (* +flambda for OCaml 4.03+ *)
         let variants =
-          if version >= (4, 03) && (version < (5, 0) || arch = `X86_64 || arch = `Aarch64) then
+          if ((version >= (4, 03) && arch <> `Aarch64) || version >= (4, 06))
+          && (version < (5, 0) || arch = `X86_64 || arch = `Aarch64) then
             [`Flambda] :: variants
           else
             variants in


### PR DESCRIPTION
```
#9 377.8 # ../../boot/ocamlrun ../../ocamlopt -nostdlib -I ../../stdlib -shared -o unix.cmxs -I . unix.cmxa
#9 377.8 # /usr/bin/ld: unix.a(unix.o): relocation R_AARCH64_ADR_PREL_PG_HI21 against symbol `camlUnix__Pmakeblock_3569' which may bind externally can not be used when making a shared object; recompile with -fPIC
#9 377.8 # unix.a(unix.o): in function `camlUnix__anon$2dfn$5b$2fhome$2fopam$2f$2eopam$2f4$2e05$2f$2eopam$2dswitch$2fbuild$2focaml$2dvariants$2e4$2e05$2e0$2bflambda$2fotherlibs$2funix$2funix$2eml$3a96$2c4$2d$2d2598$5d_511':
#9 377.8 # /home/opam/.opam/4.05/.opam-switch/build/ocaml-variants.4.05.0+flambda/otherlibs/unix/unix.ml:96:(.text+0x110): dangerous relocation: unsupported relocation
#9 377.8 # /usr/bin/ld: unix.a(unix.o): relocation R_AARCH64_ADR_PREL_PG_HI21 against symbol `camlUnix__const_block_529' which may bind externally can not be used when making a shared object; recompile with -fPIC
#9 377.8 # /home/opam/.opam/4.05/.opam-switch/build/ocaml-variants.4.05.0+flambda/otherlibs/unix/unix.ml:167:(.text+0x154): dangerous relocation: unsupported relocation
#9 377.8 # /usr/bin/ld: unix.a(unix.o): relocation R_AARCH64_ADR_PREL_PG_HI21 against symbol `camlUnix__const_block_686' which may bind externally can not be used when making a shared object; recompile with -fPIC
#9 377.8 # /home/opam/.opam/4.05/.opam-switch/build/ocaml-variants.4.05.0+flambda/otherlibs/unix/unix.ml:97:(.text+0x190): dangerous relocation: unsupported relocation
#9 377.8 # /usr/bin/ld: unix.a(unix.o): relocation R_AARCH64_ADR_PREL_PG_HI21 against symbol `camlUnix__Pmakeblock_3569' which may bind externally can not be used when making a shared object; recompile with -fPIC
```