### PR TITLE
afl does not compile on arm64 with OCaml < 4.06

### DIFF
--- a/ocaml_version.ml
+++ b/ocaml_version.ml
@@ -530,7 +530,8 @@ let compiler_variants arch ({major; minor; _} as t) =
           else
             variants in
         (* +afl for OCaml 4.05+ *)
-        if version >= (4, 05) && (version < (5, 0) || arch = `X86_64 || arch = `Aarch64) then
+        if ((version >= (4, 05) && arch <> `Aarch64) || version >= (4, 06))
+        && (version < (5, 0) || arch = `X86_64 || arch = `Aarch64) then
           [`Afl] :: variants
         else
           variants in


### PR DESCRIPTION
```
#9 271.7 # ../../boot/ocamlrun ../../ocamlopt -nostdlib -I ../../stdlib -shared -o unix.cmxs -I . unix.cmxa
#9 271.7 # /usr/bin/ld: unix.a(unix.o): relocation R_AARCH64_ADR_PREL_PG_HI21 against symbol `camlUnix' which may bind externally can not be used when making a shared object; recompile with -fPIC
#9 271.7 # unix.a(unix.o): in function `camlUnix__fun_3109':
#9 271.7 # /home/opam/.opam/4.05/.opam-switch/build/ocaml-variants.4.05.0+afl/otherlibs/unix/unix.ml:96:(.text+0x26c0): dangerous relocation: unsupported relocation
#9 271.7 # /usr/bin/ld: unix.a(unix.o): relocation R_AARCH64_ADR_PREL_PG_HI21 against symbol `camlUnix' which may bind externally can not be used when making a shared object; recompile with -fPIC
#9 271.7 # unix.a(unix.o): in function `camlUnix__handle_unix_error_1303':
#9 271.7 # /home/opam/.opam/4.05/.opam-switch/build/ocaml-variants.4.05.0+afl/otherlibs/unix/unix.ml:171:(.text+0x28c0): dangerous relocation: unsupported relocation
#9 271.7 # /usr/bin/ld: unix.a(unix.o): relocation R_AARCH64_ADR_PREL_PG_HI21 against symbol `camlUnix__fun_3162' which may bind externally can not be used when making a shared object; recompile with -fPIC
```