### PR TITLE
Add version upper bound to architecture support

### DIFF
--- a/ocaml_version.ml
+++ b/ocaml_version.ml
@@ -335,27 +335,42 @@ module Since = struct
   let options_packages = Releases.v4_12_0
 end
 
-module Has = struct
+module Until = struct
+  let arch (a:arch) =
+    match a with
+    | `I386 -> Releases.v4_14_1
+    | `Aarch32 -> Releases.v4_14_1
+    | `Aarch64 -> Releases.latest
+    | `Ppc64le -> Releases.v4_14_1
+    | `S390x -> Releases.v4_14_1
+    | `Riscv64 -> Releases.v4_14_1
+    | `X86_64 -> Releases.latest
+end
 
+module Has = struct
   let bytes v =
     match compare Since.bytes v with
-    |(-1) | 0 -> true
-    |_ -> false
+    | (-1) | 0 -> true
+    | _ -> false
 
   let arch (a:arch) v =
     match compare (Since.arch a) v with
-    |(-1) | 0 -> true
-    |_ -> false
+    | (-1) -> (
+      match compare (Until.arch a) v with
+      | 0 | 1 -> true
+      | _ -> false)
+    | 0 -> true
+    | _ -> false
 
   let autoconf v =
     match compare Since.autoconf v with
-    |(-1) | 0 -> true
-    |_ -> false
+    | (-1) | 0 -> true
+    | _ -> false
 
   let options_packages v =
     match compare Since.options_packages v with
-    |(-1) | 0 -> true
-    |_ -> false
+    | (-1) | 0 -> true
+    | _ -> false
 
   let multicore v =
     match v.major, v.minor with

--- a/ocaml_version.mli
+++ b/ocaml_version.mli
@@ -479,6 +479,13 @@ module Since : sig
       packages in opam-repository, rather than +variant packages *)
 end
 
+(** Determine the latest release an architecture appears in. *)
+module Until : sig
+  val arch : arch -> t
+  (** [arch a] will return the latest release of OCaml that the architecture
+      is supported on. *)
+end
+
 (** Test whether a release has a given feature. *)
 module Has : sig
 

--- a/ocaml_version.mli
+++ b/ocaml_version.mli
@@ -558,8 +558,8 @@ module Configure_options : sig
 end
 
 val compiler_variants : arch -> t -> t list
-(** [compiler_variants v] returns a list of configuration options that are available and useful
-    for version [v] of the compiler. *)
+(** [compiler_variants arch v] returns a list of configuration options that are available and useful
+    for version [v] of the compiler on architecture [arch]. *)
 
 val trunk_variants : arch -> t list
 (** [trunk_variants v] returns a list of OCaml version configurations that should be working and tested

--- a/test/test_unit.ml
+++ b/test/test_unit.ml
@@ -39,5 +39,37 @@ let test_compiler_variants =
       ~expect_exists:false ~expected:["domains"; "multicore"]
   ])
 
+let test_compiler_arches_upper =
+  let test name arch version ~expected =
+    ( name,
+      `Quick,
+      fun () ->
+        let has = Ocaml_version.Has.arch arch version in
+        Alcotest.(check bool __LOC__ has expected) )
+  in
+  Ocaml_version.Releases.([
+    test "x86_64 latest supported" `X86_64 latest ~expected:true;
+    test "aarch64 latest supported" `Aarch64 latest ~expected:true;
+    test "i386 latest unsupported" `I386 latest ~expected:false;
+    test "aarch32 latest unsupported" `Aarch32 latest ~expected:false;
+    test "ppc64le latest unsupported" `Ppc64le latest ~expected:false;
+    test "s390x latest unsupported" `S390x latest ~expected:false;
+    test "riscv64 latest unsupported" `Riscv64 latest ~expected:false;
+    test "i386 5.0 unsupported" `I386 v5_0_0 ~expected:false;
+    test "aarch32 5.0 unsupported" `Aarch32 v5_0_0 ~expected:false;
+    test "ppc64le 5.0 unsupported" `Ppc64le v5_0_0 ~expected:false;
+    test "s390x 5.0 unsupported" `S390x v5_0_0 ~expected:false;
+    test "riscv64 5.0 unsupported" `Riscv64 v5_0_0 ~expected:false;
+    test "i386 4.14 supported" `I386 v4_14 ~expected:true;
+    test "aarch32 4.14 supported" `Aarch32 v4_14 ~expected:true;
+    test "ppc64le 4.14 supported" `Ppc64le v4_14 ~expected:true;
+    test "s390x 4.14 supported" `S390x v4_14 ~expected:true;
+    test "riscv64 4.14 supported" `Riscv64 v4_14 ~expected:true;
+  ])
+
 let () =
-  Alcotest.run "ocaml-version" [ ("Compiler_variants", test_compiler_variants); ("Configure_options", test_configure_options) ]
+  Alcotest.run "ocaml-version" [
+    ("Compiler_variants", test_compiler_variants);
+    ("Configure_options", test_configure_options);
+    ("Compiler_arches_upper", test_compiler_arches_upper)
+  ]


### PR DESCRIPTION
OCaml 5.0 does not yet have support for many architectures that are supported by 4.14 and before. `ocaml-version` currently assumes that once a feature is introduced it is never removed, which this PR fixes.

It isn't ideal to continue to expose the `Since` module in the same way, but I don't know what other projects depend on it so I'm staying safe. If it's possible to hide it that would be ideal.

(This is working towards a fix for https://github.com/ocurrent/ocaml-ci/issues/756.)