### PR TITLE
OCaml 5.1.0 update

### DIFF
--- a/ocaml_version.ml
+++ b/ocaml_version.ml
@@ -232,12 +232,12 @@ module Releases = struct
               v4_09; v4_10; v4_11; v4_12; v4_13;
               v4_14; v5_0; v5_1 ]
 
-  let recent = [ v4_02; v4_03; v4_04; v4_05; v4_06; v4_07; v4_08; v4_09; v4_10; v4_11; v4_12; v4_13; v4_14; v5_0 ]
+  let recent = [ v4_02; v4_03; v4_04; v4_05; v4_06; v4_07; v4_08; v4_09; v4_10; v4_11; v4_12; v4_13; v4_14; v5_0; v5_1 ]
 
-  let latest = v5_0
+  let latest = v5_1
 
-  let unreleased_betas = [ v5_1 ]
-  let dev = [ v5_1; v5_2 ]
+  let unreleased_betas = [ ]
+  let dev = [ v5_2 ]
 
   let trunk =
     match dev with


### PR DESCRIPTION
This PR moves the 5.1.0 release to the released and latest category and remove it from the beta and dev list.