### PR TITLE
Add versions for OCaml 5.3

### DIFF
--- a/ocaml_version.ml
+++ b/ocaml_version.ml
@@ -214,6 +214,9 @@ module Releases = struct
   let v5_2_0 = of_string_exn "5.2.0"
   let v5_2 = v5_2_0
 
+  let v5_3_0 = of_string_exn "5.3.0"
+  let v5_3 = v5_3_0
+
   let all_patches = [
     v3_07_0; v3_07_1; v3_07_2; v3_08_0; v3_08_1;
     v3_08_2; v3_08_3; v3_08_4; v3_09_0; v3_09_1;
@@ -238,7 +241,7 @@ module Releases = struct
   let latest = v5_1
 
   let unreleased_betas = [ ]
-  let dev = [ v5_2 ]
+  let dev = [ v5_3; v5_2 ]
 
   let trunk =
     match dev with


### PR DESCRIPTION
This PR adds versions for 5.3.0 since the compiler development branch has moved to this version.