### PR TITLE
Add 5.2.0~alpha1 to `unreleased_betas`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
+## dev
+
+ * Add 5.2.0~alpha1 to `unreleased_betas` (@benmandrew #69)
+
 ## v3.6.4 (2024-01-24)
- 
+
  * Add versions for OCaml 5.3 (@Octachron #67)
 
 ## v3.6.3 (2023-12-08)

--- a/ocaml_version.ml
+++ b/ocaml_version.ml
@@ -240,7 +240,7 @@ module Releases = struct
 
   let latest = v5_1
 
-  let unreleased_betas = [ ]
+  let unreleased_betas = [ of_string_exn "5.2.0~alpha1" ]
   let dev = [ v5_3; v5_2 ]
 
   let trunk =

--- a/ocaml_version.mli
+++ b/ocaml_version.mli
@@ -434,7 +434,7 @@ module Releases : sig
       each major and minor release. *)
 
   val unreleased_betas : t list
-  (** Enumerates the latest beta / release-candidate versions for each {i
+  (** Enumerates the latest alpha / beta / release-candidate versions for each {i
       unreleased} minor OCaml series. *)
 
   val dev : t list


### PR DESCRIPTION
Supporting https://github.com/ocurrent/ocaml-ci/issues/917 and https://github.com/ocurrent/opam-repo-ci/issues/268.

`unreleased_betas` could be changed to something that better represents the set of current alphas, betas, and release candidates, but it's not that big of a deal and would be a breaking API change, so it is left as it is with a small docstring change.