### PR TITLE
Add OCaml 4.14.2 version

### DIFF
--- a/ocaml_version.ml
+++ b/ocaml_version.ml
@@ -202,7 +202,8 @@ module Releases = struct
 
   let v4_14_0 = of_string_exn "4.14.0"
   let v4_14_1 = of_string_exn "4.14.1"
-  let v4_14 = v4_14_1
+  let v4_14_2 = of_string_exn "4.14.2"
+  let v4_14 = v4_14_2
 
   let v5_0_0 = of_string_exn "5.0.0"
   let v5_0 = v5_0_0
@@ -228,7 +229,8 @@ module Releases = struct
     v4_07_1; v4_08_0; v4_08_1; v4_09_0; v4_09_1;
     v4_10_0; v4_10_1; v4_10_2; v4_11_0; v4_11_1;
     v4_11_2; v4_12_0; v4_12_1; v4_13_0; v4_13_1;
-    v4_14_0; v4_14_1; v5_0_0; v5_1_0; v5_1_1 ]
+    v4_14_0; v4_14_1; v4_14_2; v5_0_0; v5_1_0;
+    v5_1_1 ]
 
   let all = [ v3_07; v3_08; v3_09; v3_10; v3_11;
               v3_12; v4_00; v4_01; v4_02; v4_03;

--- a/ocaml_version.mli
+++ b/ocaml_version.mli
@@ -404,6 +404,9 @@ module Releases : sig
   val v4_14_1 : t
   (** Version 4.14.1 *)
 
+  val v4_14_2 : t
+  (** Version 4.14.2 *)
+
   val v4_14 : t
   (** Latest release in the 4.14.x series *)
 


### PR DESCRIPTION
This PR adds the upcoming 4.14.2 version to the list of version, and moves the last version of the 4.14 to 4.14.2.