### PR TITLE
Release of OCaml 5.3.0

### DIFF
--- a/ocaml_version.ml
+++ b/ocaml_version.ml
@@ -234,20 +234,20 @@ module Releases = struct
     v4_10_0; v4_10_1; v4_10_2; v4_11_0; v4_11_1;
     v4_11_2; v4_12_0; v4_12_1; v4_13_0; v4_13_1;
     v4_14_0; v4_14_1; v4_14_2; v5_0_0; v5_1_0;
-    v5_1_1; v5_2_0; v5_2_1 ]
+    v5_1_1; v5_2_0; v5_2_1; v5_3_0 ]
 
   let all = [ v3_07; v3_08; v3_09; v3_10; v3_11;
               v3_12; v4_00; v4_01; v4_02; v4_03;
               v4_04; v4_05; v4_06; v4_07; v4_08;
               v4_09; v4_10; v4_11; v4_12; v4_13;
-              v4_14; v5_0; v5_1; v5_2 ]
+              v4_14; v5_0; v5_1; v5_2; v5_3 ]
 
-  let recent = [ v4_02; v4_03; v4_04; v4_05; v4_06; v4_07; v4_08; v4_09; v4_10; v4_11; v4_12; v4_13; v4_14; v5_0; v5_1; v5_2 ]
+  let recent = [ v4_02; v4_03; v4_04; v4_05; v4_06; v4_07; v4_08; v4_09; v4_10; v4_11; v4_12; v4_13; v4_14; v5_0; v5_1; v5_2; v5_3 ]
 
-  let latest = v5_2
+  let latest = v5_3
 
-  let unreleased_betas = [ of_string_exn "5.3.0~rc1" ]
-  let dev = [ v5_3; v5_4 ]
+  let unreleased_betas = [ ]
+  let dev = [ v5_4 ]
 
   let trunk =
     match dev with

--- a/ocaml_version.mli
+++ b/ocaml_version.mli
@@ -431,6 +431,12 @@ module Releases : sig
   val v5_2 : t
   (** Latest release in the 5.2.x series *)
 
+  val v5_3_0 : t
+  (** Version 5.3.0 *)
+
+  val v5_3 : t
+  (** Latest release in the 5.3.x series *)
+
   val all_patches : t list
   (** [all_patches] is an enumeration of all OCaml releases, including every patch release.
       To get the major and minor releases with the latest patch version, use {!all} instead. *)


### PR DESCRIPTION
This PR updates the list of released version for the upcoming release of OCaml 5.3.0 .