### PR TITLE
Add OCaml 5.5 trunk version

### DIFF
--- a/ocaml_version.ml
+++ b/ocaml_version.ml
@@ -222,6 +222,9 @@ module Releases = struct
   let v5_4_0 = of_string_exn "5.4.0"
   let v5_4 = v5_4_0
 
+  let v5_5_0 = of_string_exn "5.5.0"
+  let v5_5 = v5_5_0
+
   let all_patches = [
     v3_07_0; v3_07_1; v3_07_2; v3_08_0; v3_08_1;
     v3_08_2; v3_08_3; v3_08_4; v3_09_0; v3_09_1;
@@ -247,7 +250,7 @@ module Releases = struct
   let latest = v5_3
 
   let unreleased_betas = [ ]
-  let dev = [ v5_4 ]
+  let dev = [ v5_4; v5_5 ]
 
   let trunk =
     match dev with


### PR DESCRIPTION
This PR adds the 5.5 branch as the new trunk, now that 5.4 lives on its release branch.