### PR TITLE
Remove 4.08 from significant releases list

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+## unreleased
+
+ * Remove 4.08 from the `significant` releases list; the lowest curated
+   version is now 4.11 (@mtelvers)
+
 ## v4.1.0 (2026-04-20)
 
  * Add OCaml 5.6 and 5.5.0~beta1 (@kit-ty-kate #88)

--- a/ocaml_version.ml
+++ b/ocaml_version.ml
@@ -254,7 +254,7 @@ module Releases = struct
   let significant =
     let last_two = match List.rev all with
       | a :: b :: _ -> [b; a] | _ -> [] in
-    List.sort_uniq compare ([ v4_08; v4_11; v4_14; v5_2 ] @ last_two)
+    List.sort_uniq compare ([ v4_11; v4_14; v5_2 ] @ last_two)
 
   let latest = v5_4
 


### PR DESCRIPTION
Drops `v4_08` from the curated base set in `Releases.significant`, so the lowest curated version is now 4.11. The `last_two` tail and `recent` list are unchanged.

See https://github.com/ocaml/opam-repository/pull/29848.