### PR TITLE
Add OCaml 5.5.0 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## v4.1.3 (2026-06-19)
+
+ * Add OCaml 5.5.0 (@Octachron #92)
+
 ## v4.1.2 (2026-06-15)
 
  * Add OCaml 4.14.4 (@Octachron #91)

--- a/ocaml_version.ml
+++ b/ocaml_version.ml
@@ -244,24 +244,26 @@ module Releases = struct
     v4_11_2; v4_12_0; v4_12_1; v4_13_0; v4_13_1;
     v4_14_0; v4_14_1; v4_14_2; v4_14_3; v4_14_4;
     v5_0_0; v5_1_0; v5_1_1; v5_2_0; v5_2_1;
-    v5_3_0; v5_4_0; v5_4_1 ]
+    v5_3_0; v5_4_0; v5_4_1; v5_5_0 ]
 
   let all = [ v3_07; v3_08; v3_09; v3_10; v3_11;
               v3_12; v4_00; v4_01; v4_02; v4_03;
               v4_04; v4_05; v4_06; v4_07; v4_08;
               v4_09; v4_10; v4_11; v4_12; v4_13;
-              v4_14; v5_0; v5_1; v5_2; v5_3; v5_4 ]
+              v4_14; v5_0; v5_1; v5_2; v5_3; v5_4;
+              v5_5
+            ]
 
-  let recent = [ v4_08; v4_09; v4_10; v4_11; v4_12; v4_13; v4_14; v5_0; v5_1; v5_2; v5_3; v5_4 ]
+  let recent = [ v4_08; v4_09; v4_10; v4_11; v4_12; v4_13; v4_14; v5_0; v5_1; v5_2; v5_3; v5_4; v5_5 ]
   let significant =
     let last_two = match List.rev all with
       | a :: b :: _ -> [b; a] | _ -> [] in
     List.sort_uniq compare ([ v4_11; v4_14; v5_2 ] @ last_two)
 
-  let latest = v5_4
+  let latest = v5_5
 
-  let unreleased_betas = [ of_string_exn "5.5.0~beta1" ]
-  let dev = [ v5_5; v5_6 ]
+  let unreleased_betas = [ ]
+  let dev = [ v5_6 ]
 
   let trunk =
     match dev with

--- a/ocaml_version.mli
+++ b/ocaml_version.mli
@@ -452,6 +452,12 @@ module Releases : sig
   val v5_4 : t
   (** Latest release in the 5.4.x series *)
 
+  val v5_5_0 : t
+  (** Version 5.5.0 *)
+
+  val v5_5 : t
+  (** Latest release in the 5.4.x series *)
+
   val all_patches : t list
   (** [all_patches] is an enumeration of all OCaml releases, including every patch release.
       To get the major and minor releases with the latest patch version, use {!all} instead. *)

--- a/ocaml_version.mli
+++ b/ocaml_version.mli
@@ -456,7 +456,7 @@ module Releases : sig
   (** Version 5.5.0 *)
 
   val v5_5 : t
-  (** Latest release in the 5.4.x series *)
+  (** Latest release in the 5.5.x series *)
 
   val all_patches : t list
   (** [all_patches] is an enumeration of all OCaml releases, including every patch release.


### PR DESCRIPTION
This PR adds the 5.5.0 version in prevision of tomorrow release.